### PR TITLE
Add setting to auto-detect react version

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,5 +24,11 @@
   "plugins": ["react"],
   "rules": {
     "react/react-in-jsx-scope": "off"
+  },
+  "settings": {
+    "react": {
+      "pragma": "React",
+      "version": "detect"
+    }
   }
 }


### PR DESCRIPTION
Removes "React version not set" warning when running yarn lint